### PR TITLE
PHP 5.3 compat - changed array shorthand

### DIFF
--- a/classes/types/base.php
+++ b/classes/types/base.php
@@ -287,7 +287,7 @@ abstract class Base {
 			$items = $this->get_items_ids( $page, $this->items_per_page );
 
 			$r = $this->search( array(
-				'fields' => [],
+				'fields' => array(),
 				'query' => array(
 					'ids' => array( 'values' => $items )
 				),


### PR DESCRIPTION
Sucks to do this but it's a small change at least for this to work with older hosts
